### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # txt.wav
 
+[![CDNJS](https://img.shields.io/cdnjs/v/txt.wav.svg)](https://cdnjs.com/libraries/txt.wav)
 ![npm version](https://badge.fury.io/js/txt.wav.svg)
 ![Code Climate](https://codeclimate.com/github/still-life-studio/txt.wav/badges/gpa.svg)
 


### PR DESCRIPTION
This will add a badge that shows the lib version on CDNJS and link to its page on CDNJS!
